### PR TITLE
Add login and teams routes with corresponding templates and tests

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -6,6 +6,9 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL,
 });
 
-Router.map(function() {});
+Router.map(function() {
+  this.route('teams');
+  this.route('login');
+});
 
 export default Router;

--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class LoginRoute extends Route {
+}

--- a/app/routes/teams.js
+++ b/app/routes/teams.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class TeamsRoute extends Route {
+}

--- a/app/templates/application.hbs
+++ b/app/templates/application.hbs
@@ -1,17 +1,1 @@
-<TeamSelector />
-
-<TeamSidebar />
-
-<!-- Channel -->
-<main class='flex-1 flex flex-col bg-white overflow-hidden channel'>
-
-  <ChannelHeader @title='Frontend Chat' @description='CSS and JS chat' />
-  {{format-timestamp '05-01-2019'}}
-  <!-- Channel Message List -->
-  <div class='py-4 flex-1 overflow-y-scroll channel-messages-list' role='list'>
-    <Message />
-    <Message />
-    <Message />
-  </div>
-  <ChannelFooter />
-</main>
+{{outlet}}

--- a/app/templates/components/team-sidebar.hbs
+++ b/app/templates/components/team-sidebar.hbs
@@ -69,10 +69,12 @@
   </nav>
 
   <footer class='mx-4 mb-2 text-white'>
-    <button
+    <LinkTo
+      @route='login'
+      @tagName='button'
       class='text-white rounded bg-grey-dark hover:bg-red-darker p-2 team-sidebar__logout-button'
     >
       Logout
-    </button>
+    </LinkTo>
   </footer>
 </section>

--- a/app/templates/login.hbs
+++ b/app/templates/login.hbs
@@ -1,0 +1,43 @@
+<div class='mx-auto'>
+  <div class='flex justify-center flex-row w-full leading-loose text-3xl'>
+    Login
+  </div>
+  <div class='flex justify-center flex-row w-full'>
+    <div class='w-full max-w-xs'>
+      <form class='bg-grey-light shadow-md rounded px-8 pt-6 pb-8 mb-4'>
+        <div class='inline-block relative w-64 mt-2'>
+          <select
+            class='block appearance-none w-full bg-white border border-grey-light hover:border-grey px-4 py-2 pr-8 rounded shadow leading-tight focus:outline-none focus:shadow-outline'
+          >
+            <option value='' disabled>Select a user</option>
+            <option value='1'>Testy Testerson</option>
+            <option value='2'>Sample McData</option>
+          </select>
+          <div
+            class='pointer-events-none absolute pin-y pin-r flex items-center px-2 text-grey-darker'
+          >
+            <svg
+              class='fill-current h-4 w-4'
+              xmlns='http://www.w3.org/2000/svg'
+              viewBox='0 0 20 20'
+            >
+              <path
+                d='M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z'
+              ></path>
+            </svg>
+          </div>
+        </div>
+        <p class='text-blue text-xs italic my-4'>
+          A validation message
+        </p>
+        <div class='flex items-center justify-between'>
+          <input
+            class='bg-grey text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline'
+            value='Sign In'
+            type='submit'
+          />
+        </div>
+      </form>
+    </div>
+  </div>
+</div>

--- a/app/templates/teams.hbs
+++ b/app/templates/teams.hbs
@@ -1,0 +1,17 @@
+<TeamSelector />
+
+<TeamSidebar />
+
+<!-- Channel -->
+<main class='flex-1 flex flex-col bg-white overflow-hidden channel'>
+
+  <ChannelHeader @title='Frontend Chat' @description='CSS and JS chat' />
+  {{format-timestamp '05-01-2019'}}
+  <!-- Channel Message List -->
+  <div class='py-4 flex-1 overflow-y-scroll channel-messages-list' role='list'>
+    <Message />
+    <Message />
+    <Message />
+  </div>
+  <ChannelFooter />
+</main>

--- a/tests/unit/routes/login-test.js
+++ b/tests/unit/routes/login-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | login', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:login');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/teams-test.js
+++ b/tests/unit/routes/teams-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | teams', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:teams');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
This pull request refactors the routing structure of the application by introducing new routes (`teams` and `login`), updating templates to use dynamic routing, and adding corresponding unit tests. The changes improve modularity and prepare the application for future feature development.

### Routing Updates:
* Updated `app/router.js` to define new routes: `teams` and `login`.

### New Route Implementations:
* Added `LoginRoute` in `app/routes/login.js` as a placeholder for the login page.
* Added `TeamsRoute` in `app/routes/teams.js` as a placeholder for the teams page.

### Template Modifications:
* Replaced the content of `app/templates/application.hbs` with `{{outlet}}` to delegate rendering to child routes.
* Updated `app/templates/components/team-sidebar.hbs` to use a `LinkTo` helper for navigating to the `login` route.
* Created a new template `app/templates/login.hbs` with a basic login form and user selection dropdown.
* Moved the previous application content to `app/templates/teams.hbs` to render under the `teams` route.

### Unit Tests:
* Added a unit test for the `login` route in `tests/unit/routes/login-test.js`.
* Added a unit test for the `teams` route in `tests/unit/routes/teams-test.js`.