### PR TITLE
Add SonarCloud configuration and coverage settings

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,38 @@
+name: Build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  sonarcloud:
+    name: SonarQube Cloud
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@latest
+
+      - name: Install ember-cli-code-coverage
+        run: npm install --save-dev ember-cli-code-coverage
+
+      - name: Test and coverage
+        run: |
+          COVERAGE=true npx ember test
+
+      - name: SonarQube Cloud Scan
+        uses: SonarSource/sonarcloud-github-action@master
+        with:
+          projectBaseDir: .
+          args: >
+            -Dsonar.javascript.lcov.reportPaths=coverage/lcov.info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/coverage-config.js
+++ b/coverage-config.js
@@ -1,0 +1,15 @@
+/* eslint-env node */
+'use strict';
+
+module.exports = {
+  reporters: ['lcov', 'html'],
+  excludes: [
+    '*/templates/**/*.js',
+    '*/tailwind/config/**/*.js',
+    'app/tailwind/**',
+    'server/**',
+    'starter-files/**',
+  ],
+  coverageFolder: 'coverage',
+  useBabelInstrumenter: true,
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
     "start": "node ./prod-server.js",
-    "test": "ember test"
+    "test": "ember test",
+    "test:coverage": "COVERAGE=true ember test"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.7.0",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,20 @@
+sonar.projectKey=arodrigue96_ember-shlack
+sonar.organization=arodrigue96
+
+# This is the name and version displayed in the SonarCloud UI.
+sonar.projectName=Ember Shlack
+sonar.projectVersion=1.0
+
+# Path to the source code
+sonar.sources=app/
+sonar.tests=tests/
+
+# Encoding of the source code
+# sonar.sourceEncoding=UTF-8
+
+# JavaScript specific configuration
+sonar.javascript.lcov.reportPaths=coverage/lcov.info
+
+# Exclude tailwind configs, static assets, etc.
+sonar.exclusions=app/tailwind/config/**/*,public/assets/**/*,server/**/*,starter-files/**/*
+sonar.coverage.exclusions=app/tailwind/**/*,app/templates/**/*,tests/**/*


### PR DESCRIPTION
This pull request introduces SonarQube integration for code quality and coverage analysis, along with configuration updates to support coverage reporting. The most important changes include adding a GitHub Actions workflow for SonarQube scans, configuring coverage exclusions, and updating test scripts to include coverage support.

### SonarQube Integration:

* [`.github/workflows/sonar.yml`](diffhunk://#diff-9a1c250ec072fc76ad44435cd9462d5693ea81f304d650922d3c2792bef267c2R1-R38): Added a GitHub Actions workflow to run SonarQube scans on `push` and `pull_request` events. The workflow installs dependencies, sets up Chrome, runs tests with coverage, and triggers the SonarQube scan.
* [`sonar-project.properties`](diffhunk://#diff-43ed9d31bea2a6d518d69836bcd1a8e6bd81bf4df96c4745792c220ca5aa549cR1-R20): Added SonarQube configuration properties, including project metadata, source paths, exclusions, and coverage report paths.

### Coverage Configuration:

* [`coverage-config.js`](diffhunk://#diff-f5a44e08b09dac82797a518cd637f97ba18287254e92fd4f98d1df1967f712f7R1-R15): Added a coverage configuration file specifying reporters, exclusions, and folder paths for coverage data.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L19-R20): Updated test scripts to include a `test:coverage` command for running tests with coverage enabled.