### PR TITLE
Feature/url model

### DIFF
--- a/app/router.js
+++ b/app/router.js
@@ -6,8 +6,14 @@ const Router = EmberRouter.extend({
   rootURL: config.rootURL,
 });
 
-Router.map(function() {
-  this.route('teams');
+Router.map(function () {
+  this.route('teams', function () {
+    //teams*
+    this.route('team', { path: ':teamId' }, function () {
+      //teams/(linkedin)
+      this.route('channel', { path: ':channelId' });
+    });
+  });
   this.route('login');
 });
 

--- a/app/routes/teams.js
+++ b/app/routes/teams.js
@@ -2,7 +2,7 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import AuthService from 'shlack/services/auth';
 
-const ALL_TEAMS = [
+export const ALL_TEAMS = [
   {
     id: 'linkedin',
     name: 'LinkedIn',

--- a/app/routes/teams.js
+++ b/app/routes/teams.js
@@ -2,6 +2,27 @@ import Route from '@ember/routing/route';
 import { inject as service } from '@ember/service';
 import AuthService from 'shlack/services/auth';
 
+const ALL_TEAMS = [
+  {
+    id: 'linkedin',
+    name: 'LinkedIn',
+    order: 2,
+    iconUrl: '/assets/img/linkedin.png',
+  },
+  {
+    id: 'ms',
+    name: 'Microsoft',
+    order: 3,
+    iconUrl: '/assets/img/microsoft.png',
+  },
+  {
+    id: 'avengers',
+    name: 'Avengers',
+    order: 4,
+    iconUrl: '/assets/img/avengers.jpg',
+  },
+];
+
 export default class TeamsRoute extends Route {
   /**
    * @type {AuthService}
@@ -15,5 +36,9 @@ export default class TeamsRoute extends Route {
     if (!this.auth.currentUserId) {
       this.transitionTo('login');
     }
+  }
+
+  async model() {
+    return ALL_TEAMS;
   }
 }

--- a/app/routes/teams/team.js
+++ b/app/routes/teams/team.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class TeamsTeamRoute extends Route {
+}

--- a/app/routes/teams/team.js
+++ b/app/routes/teams/team.js
@@ -1,4 +1,8 @@
 import Route from '@ember/routing/route';
+import { ALL_TEAMS } from '../teams';
 
 export default class TeamsTeamRoute extends Route {
+  model({ teamId }) {
+    return ALL_TEAMS.find((team) => team.id === teamId);
+  }
 }

--- a/app/routes/teams/team/channel.js
+++ b/app/routes/teams/team/channel.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default class TeamsTeamChannelRoute extends Route {
+}

--- a/app/templates/components/team-selector.hbs
+++ b/app/templates/components/team-selector.hbs
@@ -1,36 +1,25 @@
 <nav
   class='team-selector bg-indigo-darkest border-indigo-darkest border-r-2 pt-2 text-purple-lighter flex-none hidden sm:block'
 >
-  <a
-    href='/li'
-    data-team-id='li'
-    class='team-selector__team-button cursor-pointer rounded-lg p-2 pl-4 block no-underline opacity-25 opacity-100'
-  >
-    <div
-      class='bg-white h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden'
+  {{#each @teams as |team|}}
+    <LinkTo
+      @route='teams.team'
+      @model={{team.id}}
+      href='/li'
+      data-team-id='li'
+      class='team-selector__team-button cursor-pointer rounded-lg p-2 pl-4 block no-underline opacity-25 opacity-100'
     >
-      <img
-        class='team-selector__team-logo'
-        src='https://gravatar.com/avatar/0ca1be2eaded508606982feb9fea8a2b?s=200&amp;d=https://upload.wikimedia.org/wikipedia/commons/thumb/c/ca/LinkedIn_logo_initials.png/240px-LinkedIn_logo_initials.png'
-        alt='LinkedIn'
-      />
-    </div>
-  </a>
-  <a
-    href='/ms'
-    data-team-id='ms'
-    class='team-selector__team-button cursor-pointer rounded-lg p-2 pl-4 block no-underline opacity-25'
-  >
-    <div
-      class='bg-white h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden'
-    >
-      <img
-        class='team-selector__team-logo'
-        src='https://gravatar.com/avatar/0ca1be2eaded508606982feb9fea8a2b?s=200&amp;d=https://upload.wikimedia.org/wikipedia/commons/thumb/4/44/Microsoft_logo.svg/200px-Microsoft_logo.svg.png'
-        alt='Microsoft'
-      />
-    </div>
-  </a>
+      <div
+        class='bg-white h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden'
+      >
+        <img
+          class='team-selector__team-logo'
+          src={{team.iconUrl}}
+          alt={{team.name}}
+        />
+      </div>
+    </LinkTo>
+  {{/each}}
   <div class='team-selector__add-team-button cursor-pointer p-4'>
     <div
       class='bg-white opacity-25 h-12 w-12 flex items-center justify-center text-black text-2xl font-semibold rounded-lg mb-1 overflow-hidden'

--- a/app/templates/components/team-sidebar.hbs
+++ b/app/templates/components/team-sidebar.hbs
@@ -8,7 +8,7 @@
       <h1
         class='team-sidebar__team-name font-semibold text-xl leading-tight mb-1 truncate'
       >
-        LinkedIn
+        {{@team.name}}
       </h1>
 
       <div class='team-sidebar__current-user-indicator flex items-center mb-6'>
@@ -18,7 +18,7 @@
         <span
           class='team-sidebar__current-user-name text-white opacity-50 text-sm'
         >
-          Mike North
+          Aniol Rodriguez
         </span>
       </div>
     </div>

--- a/app/templates/teams.hbs
+++ b/app/templates/teams.hbs
@@ -1,17 +1,2 @@
-<TeamSelector />
-
-<TeamSidebar />
-
-<!-- Channel -->
-<main class='flex-1 flex flex-col bg-white overflow-hidden channel'>
-
-  <ChannelHeader @title='Frontend Chat' @description='CSS and JS chat' />
-  {{format-timestamp '05-01-2019'}}
-  <!-- Channel Message List -->
-  <div class='py-4 flex-1 overflow-y-scroll channel-messages-list' role='list'>
-    <Message />
-    <Message />
-    <Message />
-  </div>
-  <ChannelFooter />
-</main>
+<TeamSelector @teams={{this.model}} />
+{{outlet}}

--- a/app/templates/teams/team.hbs
+++ b/app/templates/teams/team.hbs
@@ -1,2 +1,2 @@
-<TeamSidebar />
+<TeamSidebar @team={{this.model}} />
 {{outlet}}

--- a/app/templates/teams/team.hbs
+++ b/app/templates/teams/team.hbs
@@ -1,0 +1,2 @@
+<TeamSidebar />
+{{outlet}}

--- a/app/templates/teams/team/channel.hbs
+++ b/app/templates/teams/team/channel.hbs
@@ -1,0 +1,13 @@
+<!-- Channel -->
+<main class='flex-1 flex flex-col bg-white overflow-hidden channel'>
+
+  <ChannelHeader @title='Frontend Chat' @description='CSS and JS chat' />
+  {{format-timestamp '05-01-2019'}}
+  <!-- Channel Message List -->
+  <div class='py-4 flex-1 overflow-y-scroll channel-messages-list' role='list'>
+    <Message />
+    <Message />
+    <Message />
+  </div>
+  <ChannelFooter />
+</main>

--- a/tests/acceptance/logout-test.js
+++ b/tests/acceptance/logout-test.js
@@ -12,10 +12,13 @@ module('Acceptance | logout', function (hooks) {
 
   test('visiting /teams and clicking Logout', async function (assert) {
     this.owner.lookup('service:auth').currentUserId = '1';
-    await visit('/teams'); //Go to the /teams url
+    await visit('/teams/linkedin'); //Go to the /teams url
 
     // await this.pauseTest();
-    assert.equal(currentURL(), '/teams', 'Should be on the /teams page');
+    assert.ok(
+      currentURL().startsWith('/teams'),
+      'Should be on a /teams page before logout'
+    );
 
     await click('.team-sidebar__logout-button');
     // await this.pauseTest();

--- a/tests/unit/routes/teams/team-test.js
+++ b/tests/unit/routes/teams/team-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | teams/team', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:teams/team');
+    assert.ok(route);
+  });
+});

--- a/tests/unit/routes/teams/team/channel-test.js
+++ b/tests/unit/routes/teams/team/channel-test.js
@@ -1,0 +1,11 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Route | teams/team/channel', function(hooks) {
+  setupTest(hooks);
+
+  test('it exists', function(assert) {
+    let route = this.owner.lookup('route:teams/team/channel');
+    assert.ok(route);
+  });
+});


### PR DESCRIPTION
This pull request introduces a major restructuring of the `teams` feature in the application, including updates to routing, templates, and tests. The changes enable nested routes for teams and channels, dynamically render team-specific data, and improve modularity and test coverage.

### Routing Updates:
* Updated `app/router.js` to define nested routes for teams (`teams.team`) and channels (`teams.team.channel`). This allows for more granular navigation within the `teams` feature.

### Dynamic Team Data Integration:
* Added `ALL_TEAMS` constant in `app/routes/teams.js` to store team metadata (e.g., `id`, `name`, `iconUrl`) and updated the `model` hook to return this data. [[1]](diffhunk://#diff-c06e1bf04b96d98518dad27a13ddda522c530f69c8df9b55c5096c46052ba0a5R5-R25) [[2]](diffhunk://#diff-c06e1bf04b96d98518dad27a13ddda522c530f69c8df9b55c5096c46052ba0a5R40-R43)
* Implemented `app/routes/teams/team.js` to fetch specific team data based on `teamId`.

### Template Enhancements:
* Updated `app/templates/components/team-selector.hbs` to dynamically render team buttons using the `@teams` property and `LinkTo` helper. [[1]](diffhunk://#diff-9fffb0cd44dc4e5220312076a9c9403aa36e15dfafa221bb3d825d4afa00dd4bL4-R7) [[2]](diffhunk://#diff-9fffb0cd44dc4e5220312076a9c9403aa36e15dfafa221bb3d825d4afa00dd4bL14-R22)
* Modified `app/templates/teams.hbs` to pass the `model` data to `TeamSelector` and use `{{outlet}}` for nested routes.
* Created new templates for `teams.team` (`app/templates/teams/team.hbs`) and `teams.team.channel` (`app/templates/teams/team/channel.hbs`) to display team-specific and channel-specific content. [[1]](diffhunk://#diff-aeb62577cfffc703077d9e408ee6335a01ed578b15aa4a436f08add93969d777R1-R2) [[2]](diffhunk://#diff-2a49ec5119257aceff1f6d50ade71f9750e3ba510d913d73ca21256408741ddfR1-R13)

### Test Coverage:
* Updated `tests/acceptance/logout-test.js` to adapt to the new `/teams/:teamId` route structure.
* Added unit tests for the new `teams/team` and `teams/team/channel` routes to verify their existence. [[1]](diffhunk://#diff-8aac3dab2d08f0f1eb8acfbaf2fe812e5adf07cf3cf61c3975c12410c731cb2aR1-R11) [[2]](diffhunk://#diff-94111dbf66eb73a2a7c9e158b40649affa419077b39a531ec6f6ce5987aaa9d3R1-R11)